### PR TITLE
Bump Keycloak volume to allow WAL fix to run

### DIFF
--- a/environments/acrc-prod/inventory/group_vars/all/variables.yml
+++ b/environments/acrc-prod/inventory/group_vars/all/variables.yml
@@ -75,7 +75,7 @@ infra_network_mtu: 1500
 
 # NOTE(sd109 - 2024-07-08): Latest version of Keycloak seems to require more
 # storage space so try bumping from 8GB to 20GB for now.
-keycloak_database_data_volume_size: 20Gi
+keycloak_database_data_volume_size: 21Gi
 
 # Temporary fix for Keycloak WAL shipping issue
 # NOTE(scott): Remove this once the following PR is part of an Azimuth release:


### PR DESCRIPTION
Previous fix was correct but volume was already too full for WAL shipping process to actually run... Creating a little more space allows previous fix to take effect.